### PR TITLE
Support version Python 3.8 or later

### DIFF
--- a/package/debian/control
+++ b/package/debian/control
@@ -9,4 +9,4 @@ Homepage: https://github.com/RikyIsola/AutoDND
 Package: autodnd
 Architecture: any
 Description: Add schedule to the gnome do not disturb
-Depends: coreutils, python3.8, libglib2.0-bin
+Depends: coreutils, python (>= 3.8), libglib2.0-bin


### PR DESCRIPTION
Fixes #1 

This is untested because I already have autodnd installed, but I think this is correct.  I'm guessing that this script would probably work with versions earlier than 3.8 also.